### PR TITLE
rtw_select_queue signature for kernel 4.19

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1191,12 +1191,16 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 
 
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-	, void *accel_priv
-	#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
-	, select_queue_fallback_t fallback
+	#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
+	  #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0)
+		  , void *accel_priv
+	  #else
+	    , struct net_device *sb_dev
+	  #endif
+	  #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+		  , select_queue_fallback_t fallback
+	  #endif
 	#endif
-#endif
 )
 {
 	_adapter	*padapter = rtw_netdev_priv(dev);


### PR DESCRIPTION
I was trying to get my DWA 171 dongle work with Raspbian on kernel 4.19. There was an error when compiling and it's solved with this change. 
But, the driver generated doesn't work. Once it's loaded you get a "Unknown symbol __sanitizer_cov_trace_pc" error. 
Any ideas?